### PR TITLE
Fix: remove "render: markdown" from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,14 +9,12 @@ body:
     description: A clear description of what the bug is. Please consider adding pictures and/or videos, as they really help!
     placeholder: |
       When I do X then Y happens.
-    render: markdown
   validations:
     required: true
 - type: textarea
   attributes:
     label: To Reproduce
     description: Steps to reproduce the behavior.
-    render: markdown
     placeholder: |
       1. Open map ...
       2. Do ...
@@ -27,7 +25,6 @@ body:
   attributes:
     label: Expected Behavior
     description: A clear and concise description of what you expected to happen.
-    render: markdown
     placeholder: |
       When I do X then Z should happen.
   validations:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -13,7 +13,6 @@ body:
   attributes:
     label: Describe your enhancement suggestion in more detail
     description: Feel free to add pictures or video directly to this description!
-    render: markdown
     placeholder: |
       Give a clear explanation of what you want us to improve.
       Please don't give vague, single-line suggestions like "Make button look better" or "Fix the entity that damages the player".

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,6 @@ body:
   attributes:
     label: Describe your feature suggestion in more detail
     description: Feel free to add pictures or video directly to this description!
-    render: markdown
     placeholder: |
       Give a clear explanation of what you want us to add. 
       Please don't give vague suggestions like "Make button look better" or "Add entity that damages the player".


### PR DESCRIPTION
I messed up when converting the issue templates to the new syntax, and added a property to the text input boxes that makes it harder to read them, type in them, and blocks the user from uploading files. This PR removes that property.